### PR TITLE
uninitialized abort caused immediate exit

### DIFF
--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -269,7 +269,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
     }
 
     if(state != WL_IDLE_STATUS){
-        result == WL_CONNECTED;
+        result = state == WL_CONNECTED;
         break;
     }
     yield();

--- a/WiFiManager.cpp
+++ b/WiFiManager.cpp
@@ -243,6 +243,7 @@ boolean  WiFiManager::startConfigPortal(char const *apName, char const *apPasswo
   setupConfigPortal();
   uint8_t state;
   bool result = false;
+  abort = false;
 
   if(!_configPortalIsBlocking){
     DEBUG_WM(F("Config Portal Running, non blocking/processing"));


### PR DESCRIPTION
In some cases this caused the config portal to exit right after
start